### PR TITLE
Bump schematics version for cli

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5582,11 +5582,11 @@
       }
     },
     "packages/@guidesmiths/cuckoojs-cli": {
-      "version": "0.0.2",
+      "version": "0.0.3",
       "license": "MIT",
       "dependencies": {
         "@angular-devkit/schematics-cli": "^14.2.3",
-        "@guidesmiths/cuckoojs-schematics": "^0.0.1",
+        "@guidesmiths/cuckoojs-schematics": "^0.0.2",
         "@nestjs/schematics": "^9.0.3",
         "@types/node": "^18.11.17",
         "commander": "^9.4.1",
@@ -5608,40 +5608,6 @@
       },
       "engines": {
         "node": ">= 12"
-      }
-    },
-    "packages/@guidesmiths/cuckoojs-cli/node_modules/@guidesmiths/cuckoojs-schematics": {
-      "version": "0.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "@angular-devkit/core": "^14.2.7",
-        "@angular-devkit/schematics": "^14.2.6",
-        "@types/jasmine": "~4.0.0",
-        "@types/node": "^14.15.0",
-        "copyfiles": "^2.4.1",
-        "typescript": "~4.7.2"
-      },
-      "engines": {
-        "node": ">= 12"
-      }
-    },
-    "packages/@guidesmiths/cuckoojs-cli/node_modules/@guidesmiths/cuckoojs-schematics/node_modules/@types/jasmine": {
-      "version": "4.0.3",
-      "license": "MIT"
-    },
-    "packages/@guidesmiths/cuckoojs-cli/node_modules/@guidesmiths/cuckoojs-schematics/node_modules/@types/node": {
-      "version": "14.18.35",
-      "license": "MIT"
-    },
-    "packages/@guidesmiths/cuckoojs-cli/node_modules/@guidesmiths/cuckoojs-schematics/node_modules/typescript": {
-      "version": "4.7.4",
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
       }
     },
     "packages/@guidesmiths/cuckoojs-schematics": {
@@ -6208,7 +6174,7 @@
       "version": "file:packages/@guidesmiths/cuckoojs-cli",
       "requires": {
         "@angular-devkit/schematics-cli": "^14.2.3",
-        "@guidesmiths/cuckoojs-schematics": "^0.0.1",
+        "@guidesmiths/cuckoojs-schematics": "^0.0.2",
         "@nestjs/schematics": "^9.0.3",
         "@types/jest": "^29.2.4",
         "@types/node": "^18.11.17",
@@ -6222,30 +6188,6 @@
         "loading-cli": "^1.1.0",
         "ts-jest": "^29.0.3",
         "typescript": "^4.9.4"
-      },
-      "dependencies": {
-        "@guidesmiths/cuckoojs-schematics": {
-          "version": "0.0.1",
-          "requires": {
-            "@angular-devkit/core": "^14.2.7",
-            "@angular-devkit/schematics": "^14.2.6",
-            "@types/jasmine": "~4.0.0",
-            "@types/node": "^14.15.0",
-            "copyfiles": "^2.4.1",
-            "typescript": "~4.7.2"
-          },
-          "dependencies": {
-            "@types/jasmine": {
-              "version": "4.0.3"
-            },
-            "@types/node": {
-              "version": "14.18.35"
-            },
-            "typescript": {
-              "version": "4.7.4"
-            }
-          }
-        }
       }
     },
     "@guidesmiths/cuckoojs-schematics": {

--- a/packages/@guidesmiths/cuckoojs-cli/package.json
+++ b/packages/@guidesmiths/cuckoojs-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guidesmiths/cuckoojs-cli",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "CuckooJS CLI",
   "keywords": [
     "schematics",
@@ -54,7 +54,7 @@
   },
   "dependencies": {
     "@angular-devkit/schematics-cli": "^14.2.3",
-    "@guidesmiths/cuckoojs-schematics": "^0.0.1",
+    "@guidesmiths/cuckoojs-schematics": "^0.0.2",
     "@nestjs/schematics": "^9.0.3",
     "@types/node": "^18.11.17",
     "commander": "^9.4.1",


### PR DESCRIPTION
## Description
Bump schematics version in CLI package

## Related Issue
[#57](https://github.com/onebeyond/cuckoojs/issues/57)

## Motivation and Context
Version 0.0.2 of `schematics` package includes lambda functionality. Currently, the CLI uses 0.0.1 and gets an error when executing `cuckoo lambda n <folder>`

## How Has This Been Tested?

## Screenshots (if appropriate):

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
