### PR TITLE
Check version changes for triggering releases

### DIFF
--- a/.github/workflows/cuckoojs-schematics-npm-publish.yml
+++ b/.github/workflows/cuckoojs-schematics-npm-publish.yml
@@ -48,9 +48,23 @@ jobs:
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_GUIDESMITHS }}
 
+  check-cuckoojs-cli-version:
+    runs-on: ubuntu-latest
+    outputs:
+      version-changed: ${{ steps.version-change.outputs.version-changed }}
+    steps:
+      - name: Check-out the repository
+        uses: actions/checkout@v3
+      - name: Check version changes
+        uses: EndBug/version-check@v2
+        id: version-changed
+        with:
+          file-name: ./packages/@guidesmiths/cuckoojs-cli/package.json
+
   publish-npm-cuckoojs-cli:
     runs-on: ubuntu-latest
-    needs: publish-npm-cuckoojs-schematics
+    needs: check-cuckoojs-cli-version
+    if: ${{ needs.check-cuckoojs-cli-version.outputs.version-changed }} === "true"
     steps:
     - name: Check-out the repository
       uses: actions/checkout@v3

--- a/.github/workflows/cuckoojs-schematics-npm-publish.yml
+++ b/.github/workflows/cuckoojs-schematics-npm-publish.yml
@@ -8,7 +8,7 @@ jobs:
   check-cuckoojs-schematics-version:
     runs-on: ubuntu-latest
     outputs:
-      version-changed: ${{ steps.version-change.outputs.version-changed }}
+      version-changed: ${{ steps.version-changed.outputs.version-changed }}
     steps:
       - name: Check-out the repository
         uses: actions/checkout@v3
@@ -51,7 +51,7 @@ jobs:
   check-cuckoojs-cli-version:
     runs-on: ubuntu-latest
     outputs:
-      version-changed: ${{ steps.version-change.outputs.version-changed }}
+      version-changed: ${{ steps.version-changed.outputs.version-changed }}
     steps:
       - name: Check-out the repository
         uses: actions/checkout@v3

--- a/.github/workflows/cuckoojs-schematics-npm-publish.yml
+++ b/.github/workflows/cuckoojs-schematics-npm-publish.yml
@@ -21,7 +21,6 @@ jobs:
   publish-npm-cuckoojs-schematics:
     runs-on: ubuntu-latest
     needs: check-cuckoojs-schematics-version
-    if: ${{ needs.check-cuckoojs-schematics-version.outputs.version-changed }} === "true"
     steps:
     - name: Check-out the repository
       uses: actions/checkout@v3
@@ -44,6 +43,7 @@ jobs:
     - name: Build artifact
       run: npm run build -w @guidesmiths/cuckoojs-schematics
     - name: Publish package to npm
+      if: ${{ needs.check-cuckoojs-schematics-version.outputs.version-changed }} === "true"
       run: npm publish --ignore-scripts --access public -w @guidesmiths/cuckoojs-schematics
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_GUIDESMITHS }}

--- a/.github/workflows/cuckoojs-schematics-npm-publish.yml
+++ b/.github/workflows/cuckoojs-schematics-npm-publish.yml
@@ -15,6 +15,8 @@ jobs:
       - name: Check version changes
         uses: EndBug/version-check@v2
         id: version-changed
+        with:
+          file-name: ./packages/@guidesmiths/cuckoojs-schematics/package.json
 
   publish-npm-cuckoojs-schematics:
     runs-on: ubuntu-latest

--- a/.github/workflows/cuckoojs-schematics-npm-publish.yml
+++ b/.github/workflows/cuckoojs-schematics-npm-publish.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Check version changes
         uses: EndBug/version-check@v2
-        id: version-change
+        id: version-changed
 
   publish-npm-cuckoojs-schematics:
     runs-on: ubuntu-latest

--- a/.github/workflows/cuckoojs-schematics-npm-publish.yml
+++ b/.github/workflows/cuckoojs-schematics-npm-publish.yml
@@ -21,7 +21,7 @@ jobs:
   publish-npm-cuckoojs-schematics:
     runs-on: ubuntu-latest
     needs: check-cuckoojs-schematics-version
-    if: ${{ needs.check-cuckoojs-schematics.outputs.version-changed }} === "true"
+    if: ${{ needs.check-cuckoojs-schematics-version.outputs.version-changed }} === "true"
     steps:
     - name: Check-out the repository
       uses: actions/checkout@v3

--- a/.github/workflows/cuckoojs-schematics-npm-publish.yml
+++ b/.github/workflows/cuckoojs-schematics-npm-publish.yml
@@ -5,8 +5,21 @@ on:
     types: [ published ]
 
 jobs:
+  check-cuckoojs-schematics:
+    runs-on: ubuntu-latest
+    outputs:
+      version-changed: ${{ steps.version-change.outputs.version-changed }}
+    steps:
+      - name: Check-out the repository
+        uses: actions/checkout@v3
+      - name: Check version changes
+        uses: EndBug/version-check@v2
+        id: version-change
+
   publish-npm-cuckoojs-schematics:
     runs-on: ubuntu-latest
+    needs: check-cuckoojs-schematics
+    if: ${{ needs.check-cuckoojs-schematics.outputs.version-changed }} === "true"
     steps:
     - name: Check-out the repository
       uses: actions/checkout@v3

--- a/.github/workflows/cuckoojs-schematics-npm-publish.yml
+++ b/.github/workflows/cuckoojs-schematics-npm-publish.yml
@@ -5,7 +5,7 @@ on:
     types: [ published ]
 
 jobs:
-  check-cuckoojs-schematics:
+  check-cuckoojs-schematics-version:
     runs-on: ubuntu-latest
     outputs:
       version-changed: ${{ steps.version-change.outputs.version-changed }}
@@ -20,7 +20,7 @@ jobs:
 
   publish-npm-cuckoojs-schematics:
     runs-on: ubuntu-latest
-    needs: check-cuckoojs-schematics
+    needs: check-cuckoojs-schematics-version
     if: ${{ needs.check-cuckoojs-schematics.outputs.version-changed }} === "true"
     steps:
     - name: Check-out the repository

--- a/.github/workflows/cuckoojs-schematics-npm-publish.yml
+++ b/.github/workflows/cuckoojs-schematics-npm-publish.yml
@@ -63,7 +63,7 @@ jobs:
 
   publish-npm-cuckoojs-cli:
     runs-on: ubuntu-latest
-    needs: check-cuckoojs-cli-version
+    needs: [check-cuckoojs-cli-version, publish-npm-cuckoojs-schematics]
     if: ${{ needs.check-cuckoojs-cli-version.outputs.version-changed }} === "true"
     steps:
     - name: Check-out the repository


### PR DESCRIPTION
## Description
Add the GitHub action [`Version Check`](https://github.com/marketplace/actions/version-check) to trigger release for the cli and schematics package conditionally if the version changed in the `package.json`. I've also removed the dependency via `needs` between both packages.

## Related Issue
#59 

## Motivation and Context
Currently, the release of the cli package has a dependency with the schematics package via `needs` command on the action. This means that the release of the cli will only be done if the release of the schematics is successful. In our last release we only changed the version of the cli package, and the schematics action did still try to release again using the same version, getting an error. This, in turn, it's preventing the release of the cli package, blocking the release workflow.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
